### PR TITLE
fix: onWhatsApp query for multiple jids

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -167,22 +167,17 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	}
 
 	const onWhatsApp = async(...jids: string[]) => {
-		const results = await interactiveQuery(
-			[
-				{
-					tag: 'user',
-					attrs: {},
-					content: jids.map(
-						jid => ({
-							tag: 'contact',
-							attrs: {},
-							content: `+${jid}`
-						})
-					)
-				}
-			],
-			{ tag: 'contact', attrs: {} }
-		)
+		const query = { tag: 'contact', attrs: {} };
+		const list = jids.map((jid) => ({
+			tag: 'user',
+			attrs: {},
+			content: [{
+				tag: 'contact',
+				attrs: {},
+				content: jid,
+			}],
+		}));
+		const results = await interactiveQuery(list, query);
 
 		return results.map(user => {
 			const contact = getBinaryNodeChild(user, 'contact')


### PR DESCRIPTION
The current query in `onWhatsApp` doesn't work when multiple `jid` args are provided (the request always times out).